### PR TITLE
Disable CI on push to feature branches

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   build:
+    if: >-
+      github.repository_owner != 'Jackenmen'
+      || github.event_name != 'push'
+      || github.ref == 'refs/heads/main'
     runs-on: windows-latest
     steps:
       - name: Clone the repository

--- a/.github/workflows/style.yaml
+++ b/.github/workflows/style.yaml
@@ -5,6 +5,10 @@ on:
 
 jobs:
   style:
+    if: >-
+      github.repository_owner != 'Jackenmen'
+      || github.event_name != 'push'
+      || github.ref == 'refs/heads/main'
     runs-on: windows-latest
     steps:
       - name: Set git to use LF


### PR DESCRIPTION
Prevents duplicated runs that both counts towards my available GH Actions minutes *and* slows down the overall run due to concurrency limits.