### PR TITLE
Add missing OnPropertyChanged for SavedPosition

### DIFF
--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -239,7 +239,7 @@
                         </Grid.RowDefinitions>
                         <TextBlock
                             Name="SavedCoordinatesStatusText"
-                            Text="{Binding SavedPosition}"
+                            Text="{Binding SavedPositionText}"
                             HorizontalAlignment="Center"
                             Grid.Row="1" />
                         <local:Magnifier

--- a/src/Indexer/ViewModel/MainViewModel.cs
+++ b/src/Indexer/ViewModel/MainViewModel.cs
@@ -121,7 +121,7 @@ namespace Indexer.ViewModel
             }
         }
         public bool HasImages => _session?.CurrentImageIndex != null;
-        public string SavedPosition
+        public string SavedPositionText
         {
             get
             {
@@ -296,6 +296,7 @@ namespace Indexer.ViewModel
                 OnPropertyChanged(nameof(CurrentBitmapImage));
                 OnPropertyChanged(nameof(CurrentLabel));
                 OnPropertyChanged(nameof(CurrentLabels));
+                OnPropertyChanged(nameof(SavedPositionText));
                 OnPropertyChanged(nameof(CurrentHint));
                 OnPropertyChanged(nameof(CurrentHintImage));
                 OnPropertyChanged(nameof(CurrentHintBitmapImage));
@@ -327,6 +328,7 @@ namespace Indexer.ViewModel
             );
             OnPropertyChanged(nameof(CurrentLabel));
             OnPropertyChanged(nameof(CurrentLabels));
+            OnPropertyChanged(nameof(SavedPositionText));
         }
 
         public void SetCurrentLabelPosition(int x, int y)
@@ -350,6 +352,7 @@ namespace Indexer.ViewModel
             currentLabel.Y = y;
             OnPropertyChanged(nameof(CurrentLabel));
             OnPropertyChanged(nameof(CurrentLabels));
+            OnPropertyChanged(nameof(SavedPositionText));
         }
 
         public void RemoveCurrentLabelPosition()
@@ -371,6 +374,7 @@ namespace Indexer.ViewModel
 
             OnPropertyChanged(nameof(CurrentLabel));
             OnPropertyChanged(nameof(CurrentLabels));
+            OnPropertyChanged(nameof(SavedPositionText));
         }
 
         public void SwitchToNextLabel()
@@ -400,6 +404,7 @@ namespace Indexer.ViewModel
 
             IsSessionModified = true;
             OnPropertyChanged(nameof(CurrentLabel));
+            OnPropertyChanged(nameof(SavedPositionText));
             OnPropertyChanged(nameof(CurrentHint));
             OnPropertyChanged(nameof(CurrentHintImage));
             OnPropertyChanged(nameof(CurrentHintBitmapImage));


### PR DESCRIPTION
Fixes the saved position not showing in the UI due to missing OnPropertyChanged call. OnPropertyChanged calls are required for proper event propagation to a view that data-binds the view model.

Additionally, I renamed `SavedPosition` to `SavedPositionText` as it is a better name (this will be clearer once I make the PR for #19).