### PR TITLE
Improve adherence to MVVM pattern with ImageViewModel

### DIFF
--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -181,14 +181,14 @@
                             <RowDefinition Height="*" />
                             <RowDefinition Height="20" />
                         </Grid.RowDefinitions>
-                        <Image
+                        <local:MemoryBackedImage
                             Grid.Row="0"
                             MouseMove="MainImage_MouseMove"
                             MouseLeave="MainImage_MouseLeave"
                             MouseDown="MainImage_MouseDown"
-                            Name="MainImage"
+                            x:Name="MainImage"
                             Stretch="Uniform"
-                            Source="{Binding CurrentBitmapImage}" />
+                            StreamSource="{Binding CurrentBitmapImage}" />
                         <Grid Grid.Row="1">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="auto" />
@@ -250,7 +250,7 @@
                             Grid.Row="1" />
                         <local:Magnifier
                             ZoomFactor="1"
-                            ImageBitmap="{Binding CurrentBitmapImage}"
+                            ImageBitmap="{Binding BitmapSource, ElementName=MainImage}"
                             CurrentLabel="{Binding CurrentLabel}"
                             ImageCursor="{Binding ImageCursorPosition}"
                             Height="250"
@@ -264,11 +264,11 @@
                             Name="Magnifier"
                             Grid.Row="3"
                             Focusable="false" />
-                        <Image
-                            Source="{Binding CurrentHintBitmapImage}"
+                        <local:MemoryBackedImage
+                            StreamSource="{Binding CurrentHintBitmapImage}"
                             Height="256"
                             Width="256"
-                            Name="ReferenceImage"
+                            x:Name="ReferenceImage"
                             Grid.Row="5" />
                         <TextBlock
                             Name="ReferenceImageDecription"

--- a/src/Indexer/View/MemoryBackedImage.cs
+++ b/src/Indexer/View/MemoryBackedImage.cs
@@ -1,0 +1,70 @@
+using System.IO;
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Media.Imaging;
+
+namespace Indexer.View
+{
+    public class MemoryBackedImage : Image
+    {
+        public static readonly DependencyProperty StreamSourceProperty
+            = DependencyProperty.Register(
+                "StreamSource",
+                typeof(MemoryStream),
+                typeof(MemoryBackedImage),
+                new PropertyMetadata(default(MemoryStream), OnStreamSourceChange)
+            );
+        public MemoryStream StreamSource
+        {
+            get => (MemoryStream)GetValue(StreamSourceProperty);
+            set => SetValue(StreamSourceProperty, value);
+        }
+
+        public static readonly DependencyProperty BitmapSourceProperty
+            = DependencyProperty.Register(
+                "BitmapSource",
+                typeof(BitmapImage),
+                typeof(MemoryBackedImage),
+                new PropertyMetadata(default(BitmapImage))
+            );
+        public BitmapImage? BitmapSource
+        {
+            get => (BitmapImage)GetValue(BitmapSourceProperty);
+            private set => SetValue(BitmapSourceProperty, value);
+        }
+
+        public MemoryBackedImage()
+        {
+            UpdateSource();
+        }
+
+        private static void OnStreamSourceChange(
+            DependencyObject sender, DependencyPropertyChangedEventArgs e
+        )
+        {
+            var self = (MemoryBackedImage)sender;
+            if (self is null)
+            {
+                return;
+            }
+            self.UpdateSource();
+        }
+
+        private void UpdateSource()
+        {
+            if (StreamSource is null)
+            {
+                BitmapSource = null;
+                Source = BitmapSource;
+                return;
+            }
+            var bitmapImage = new BitmapImage();
+            bitmapImage.BeginInit();
+            bitmapImage.StreamSource = StreamSource;
+            bitmapImage.CacheOption = BitmapCacheOption.OnLoad;
+            bitmapImage.EndInit();
+            BitmapSource = bitmapImage;
+            Source = BitmapSource;
+        }
+    }
+}

--- a/src/Indexer/ViewModel/ImageViewModel.cs
+++ b/src/Indexer/ViewModel/ImageViewModel.cs
@@ -1,12 +1,7 @@
 using System;
-using System.Collections.Generic;
 using System.Drawing;
 using System.Drawing.Imaging;
 using System.IO;
-using System.Windows.Media;
-using System.Windows.Media.Imaging;
-
-using Color = System.Windows.Media.Color;
 
 namespace Indexer.ViewModel
 {
@@ -15,9 +10,9 @@ namespace Indexer.ViewModel
         private const int PropertyTagOrientation = 0x0112;
 
         public string Path { get; private set; }
-        public BitmapSource? LoadedImage { get; private set; }
-        public int Height => LoadedImage is null ? 0 : LoadedImage.PixelHeight;
-        public int Width => LoadedImage is null ? 0 : LoadedImage.PixelWidth;
+        public MemoryStream? LoadedImage { get; set; }
+        public int Height { get; private set; }
+        public int Width { get; private set; }
         public int OriginalOrientation { get; private set; }
 
         public ImageViewModel(string path)
@@ -49,23 +44,13 @@ namespace Indexer.ViewModel
             }
             catch (FileNotFoundException)
             {
-                LoadedImage = BitmapImage.Create(
-                    128,
-                    128,
-                    96,
-                    96,
-                    PixelFormats.Indexed1,
-                    new BitmapPalette(new List<Color> { Colors.Black }),
-                    new byte[2048],
-                    16
-                );
-                OnPropertyChanged(nameof(LoadedImage));
-                OnPropertyChanged(nameof(Height));
-                OnPropertyChanged(nameof(Width));
-                OnPropertyChanged(nameof(OriginalOrientation));
-                return;
+                using var pixel = new Bitmap(1, 1);
+                pixel.SetPixel(0, 0, Color.White);
+                tmpBitmap = new Bitmap(pixel, 128, 128);
             }
             using var bitmap = tmpBitmap;
+            Width = bitmap.Width;
+            Height = bitmap.Width;
 
             try
             {
@@ -104,13 +89,10 @@ namespace Indexer.ViewModel
 
             using var ms = new MemoryStream();
             bitmap.Save(ms, ImageFormat.Bmp);
-            var bitmapImage = new BitmapImage();
-            bitmapImage.BeginInit();
-            ms.Seek(0, SeekOrigin.Begin);
-            bitmapImage.StreamSource = ms;
-            bitmapImage.CacheOption = BitmapCacheOption.OnLoad;
-            bitmapImage.EndInit();
-            LoadedImage = bitmapImage;
+            var buffer = ms.ToArray();
+            LoadedImage = new MemoryStream(
+                buffer, 0, buffer.Length, writable: false, publiclyVisible: false
+            );
 
             OnPropertyChanged(nameof(LoadedImage));
             OnPropertyChanged(nameof(Height));

--- a/src/Indexer/ViewModel/MainViewModel.cs
+++ b/src/Indexer/ViewModel/MainViewModel.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Drawing;
 using System.IO;
 using System.Linq;
-using System.Windows.Media.Imaging;
 
 using Indexer.Collections;
 using Indexer.Model;
@@ -89,7 +88,7 @@ namespace Indexer.ViewModel
             }
         }
         public ImageViewModel? CurrentImage { get; private set; }
-        public BitmapSource? CurrentBitmapImage => CurrentImage?.LoadedImage;
+        public MemoryStream? CurrentBitmapImage => CurrentImage?.LoadedImage;
         public LabelVMObservableCollection CurrentLabels
         {
             get
@@ -104,7 +103,7 @@ namespace Indexer.ViewModel
         }
         public HintViewModel? CurrentHint { get; private set; }
         public ImageViewModel? CurrentHintImage { get; private set; }
-        public BitmapSource? CurrentHintBitmapImage => CurrentHint?.Image?.LoadedImage;
+        public MemoryStream? CurrentHintBitmapImage => CurrentHint?.Image?.LoadedImage;
         public LabelViewModel? CurrentLabel
         {
             get


### PR DESCRIPTION
When I was looking at #38 and #40, I had a chance to reflect on the current design and realized that the view model layer is doing a bit too much regarding the image - it exposes BitmapSource which is specifically a presentation layer (WPF) class. I decided to rework this slightly such that we keep presentation-specific behavior in the view layer by creating a new `MemoryBackedImage` component that is a subclass of Image and handles the creation of `BitmapSource` from `MemoryStream` that is provided by the `ImageViewModel`. I also have an appropriate change to #38 prepared which further extends this component to support drawing labels.