### PR TITLE
Fix scaling issues

### DIFF
--- a/src/Indexer/View/ImageWithLabels.cs
+++ b/src/Indexer/View/ImageWithLabels.cs
@@ -104,7 +104,8 @@ namespace Indexer.View
             Drawing = new DrawingVisual();
             var drawingContext = Drawing.RenderOpen();
             drawingContext.DrawImage(
-                BitmapSource, new Rect(0, 0, BitmapSource.Width, BitmapSource.Height)
+                BitmapSource,
+                new Rect(0, 0, BitmapSource.PixelWidth, BitmapSource.PixelHeight)
             );
             foreach (var label in CurrentLabels)
             {
@@ -123,8 +124,8 @@ namespace Indexer.View
             var rtb = new RenderTargetBitmap(
                 BitmapSource.PixelWidth,
                 BitmapSource.PixelHeight,
-                BitmapSource.DpiX,
-                BitmapSource.DpiY,
+                96,
+                96,
                 PixelFormats.Pbgra32
             );
             rtb.Render(Drawing);

--- a/src/Indexer/View/Magnifier.cs
+++ b/src/Indexer/View/Magnifier.cs
@@ -172,6 +172,11 @@ namespace Indexer.View
 
         private void TriggerViewBoxUpdate(bool resetViewBox = false)
         {
+            if (ImageBitmap == null)
+            {
+                ViewBox = new Rect(0, 0, 0, 0);
+                return;
+            }
             int x = 0;
             int y = 0;
             if (CurrentLabel != null)
@@ -189,9 +194,13 @@ namespace Indexer.View
                 // keep the current viewbox
                 return;
             }
-            var width = MagnifierRectangle.ActualWidth * (1 / ZoomFactor);
-            var height = MagnifierRectangle.ActualHeight * (1 / ZoomFactor);
-            ViewBox = new Rect(x - width / 2, y - height / 2, width, height);
+            var factorX = 96 / (ImageBitmap.DpiX * ZoomFactor);
+            var factorY = 96 / (ImageBitmap.DpiY * ZoomFactor);
+            var width = factorX * MagnifierRectangle.ActualWidth;
+            var height = factorY * MagnifierRectangle.ActualHeight;
+            ViewBox = new Rect(
+                factorX * x - width / 2, factorY * y - height / 2, width, height
+            );
         }
     }
 }

--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -188,6 +188,7 @@
                             MouseDown="MainImage_MouseDown"
                             x:Name="MainImage"
                             Stretch="Uniform"
+                            StretchDirection="DownOnly"
                             StreamSource="{Binding CurrentBitmapImage}"
                             CurrentLabel="{Binding CurrentLabel}"
                             CurrentLabels="{Binding CurrentLabels}" />

--- a/src/Indexer/View/MainWindow.xaml.cs
+++ b/src/Indexer/View/MainWindow.xaml.cs
@@ -292,8 +292,8 @@ namespace Indexer.View
         private Point GetImageCursorPosition(MouseEventArgs e)
         {
             Point mousePos = e.GetPosition(MainImage);
-            var x = mousePos.X * MainImage.Source.Width / MainImage.ActualWidth;
-            var y = mousePos.Y * MainImage.Source.Width / MainImage.ActualWidth;
+            var x = mousePos.X * Data.CurrentImage!.Width / MainImage.ActualWidth;
+            var y = mousePos.Y * Data.CurrentImage!.Height / MainImage.ActualHeight;
             return new Point((int)x, (int)y);
         }
 

--- a/src/Indexer/ViewModel/ImageViewModel.cs
+++ b/src/Indexer/ViewModel/ImageViewModel.cs
@@ -50,7 +50,7 @@ namespace Indexer.ViewModel
             }
             using var bitmap = tmpBitmap;
             Width = bitmap.Width;
-            Height = bitmap.Width;
+            Height = bitmap.Height;
 
             try
             {


### PR DESCRIPTION
Solves a couple of issues:
- `y` in the `GetImageCursorPosition()` and `ImageViewModel.Height` using width rather than height
- main image stretching beyond its actual size
- DPI-related issues - if the image's DPI wasn't 96, we didn't calculate a few things properly