### PR TITLE
Use checkerboard as background for image and magnifier

### DIFF
--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -19,6 +19,19 @@
     </Window.DataContext>
     <Window.Resources>
         <BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter" />
+        <DrawingBrush
+            x:Key="CheckerboardPattern"
+            TileMode="Tile"
+            Viewport="0,0,32,32"
+            ViewportUnits="Absolute"
+        >
+            <DrawingBrush.Drawing>
+                <DrawingGroup>
+                    <GeometryDrawing Geometry="M0,0 H2 V2 H0 Z" Brush="White"/>
+                    <GeometryDrawing Geometry="M0,0 H1 V1 H2 V2 H1 V1 H0 Z" Brush="LightGray"/>
+                </DrawingGroup>
+            </DrawingBrush.Drawing>
+        </DrawingBrush>
     </Window.Resources>
     <Grid>
         <DockPanel>
@@ -198,6 +211,7 @@
                             HorizontalScrollBarVisibility="Disabled"
                             PreviewMouseWheel="MainImageScrollViewer_PreviewMouseWheel"
                             Focusable="false"
+                            Background="{StaticResource CheckerboardPattern}"
                         >
                             <local:ImageWithLabels
                                 MouseMove="MainImage_MouseMove"
@@ -281,6 +295,7 @@
                                 SavedPosition="{Binding SavedPosition}"
                                 ImageCursor="{Binding ImageCursorPosition}"
                                 Height="250"
+                                Background="{StaticResource CheckerboardPattern}"
                                 Grid.Row="2" />
                             <Slider
                                 Minimum="1"


### PR DESCRIPTION
Looks like this and aims to simplify locating the end bounds of an image in cases where the pixels near bounds are of white-ish color, see:
![Indexer_2023-06-06_02-03-33](https://github.com/pginf-pg-9kisi2023/indexer-app/assets/6032823/57b3d655-d518-44e9-b6b6-e086cec8d72e)

I don't know if it's really necessary, it is useful for my own testing but may not make sense in a real-world use case. TBD.