### PR TITLE
Make Magnifier a bit more generic by removing ViewModel dependency

### DIFF
--- a/src/Indexer/View/Magnifier.cs
+++ b/src/Indexer/View/Magnifier.cs
@@ -5,8 +5,6 @@ using System.Windows.Media;
 using System.Windows.Media.Imaging;
 using System.Windows.Shapes;
 
-using Indexer.ViewModel;
-
 using Point = System.Drawing.Point;
 
 namespace Indexer.View
@@ -26,17 +24,17 @@ namespace Indexer.View
             set => SetValue(ImageBitmapProperty, value);
         }
 
-        public static readonly DependencyProperty CurrentLabelProperty
+        public static readonly DependencyProperty SavedPositionProperty
             = DependencyProperty.Register(
-                "CurrentLabel",
-                typeof(LabelViewModel),
+                "SavedPosition",
+                typeof(Point?),
                 typeof(Magnifier),
-                new PropertyMetadata(default(LabelViewModel), OnCurrentLabelChange)
+                new PropertyMetadata(default(Point?), OnSavedPositionChange)
             );
-        public LabelViewModel? CurrentLabel
+        public Point? SavedPosition
         {
-            get => (LabelViewModel)GetValue(CurrentLabelProperty);
-            set => SetValue(CurrentLabelProperty, value);
+            get => (Point?)GetValue(SavedPositionProperty);
+            set => SetValue(SavedPositionProperty, value);
         }
         public static readonly DependencyProperty ImageCursorProperty
             = DependencyProperty.Register(
@@ -214,7 +212,7 @@ namespace Indexer.View
             self.TriggerViewBoxUpdate();
         }
 
-        private static void OnCurrentLabelChange(
+        private static void OnSavedPositionChange(
             DependencyObject sender, DependencyPropertyChangedEventArgs e
         )
         {
@@ -225,14 +223,6 @@ namespace Indexer.View
             }
 
             self.TriggerViewBoxUpdate();
-            if (e.OldValue is LabelViewModel oldValue)
-            {
-                oldValue.PropertyChanged -= self.OnLabelPropertyChanged;
-            }
-            if (e.NewValue is LabelViewModel newValue)
-            {
-                newValue.PropertyChanged += self.OnLabelPropertyChanged;
-            }
         }
 
         private void OnLabelPropertyChanged(object? sender, PropertyChangedEventArgs e)
@@ -264,15 +254,15 @@ namespace Indexer.View
             }
             int x = 0;
             int y = 0;
-            if (CurrentLabel != null)
+            if (SavedPosition is Point savedPosition)
             {
-                x = CurrentLabel.X;
-                y = CurrentLabel.Y;
+                x = savedPosition.X;
+                y = savedPosition.Y;
             }
-            else if (ImageCursor is Point pos)
+            else if (ImageCursor is Point cursor)
             {
-                x = pos.X;
-                y = pos.Y;
+                x = cursor.X;
+                y = cursor.Y;
             }
             else if (!resetViewBox)
             {

--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -278,7 +278,7 @@
                             <local:Magnifier
                                 ZoomFactor="{Binding Value, ElementName=Magnifier}"
                                 ImageBitmap="{Binding BitmapSource, ElementName=MainImage}"
-                                CurrentLabel="{Binding CurrentLabel}"
+                                SavedPosition="{Binding SavedPosition}"
                                 ImageCursor="{Binding ImageCursorPosition}"
                                 Height="250"
                                 Grid.Row="2" />

--- a/src/Indexer/ViewModel/MainViewModel.cs
+++ b/src/Indexer/ViewModel/MainViewModel.cs
@@ -119,16 +119,17 @@ namespace Indexer.ViewModel
                 return "";
             }
         }
+        public Point? SavedPosition => CurrentLabel?.Position;
         public string SavedPositionText
         {
             get
             {
                 var currentLabel = CurrentLabel;
-                if (currentLabel is null)
+                if (SavedPosition is Point pos)
                 {
-                    return "";
+                    return $"{pos.X}, {pos.Y}";
                 }
-                return $"{currentLabel.X}, {currentLabel.Y}";
+                return "";
             }
         }
 
@@ -298,6 +299,7 @@ namespace Indexer.ViewModel
                 OnPropertyChanged(nameof(CurrentBitmapImage));
                 OnPropertyChanged(nameof(CurrentLabel));
                 OnPropertyChanged(nameof(CurrentLabels));
+                OnPropertyChanged(nameof(SavedPosition));
                 OnPropertyChanged(nameof(SavedPositionText));
                 OnPropertyChanged(nameof(CurrentHint));
                 OnPropertyChanged(nameof(CurrentHintImage));
@@ -331,6 +333,7 @@ namespace Indexer.ViewModel
             CurrentLabels.TriggerReset();
             OnPropertyChanged(nameof(CurrentLabel));
             OnPropertyChanged(nameof(CurrentLabels));
+            OnPropertyChanged(nameof(SavedPosition));
             OnPropertyChanged(nameof(SavedPositionText));
         }
 
@@ -356,6 +359,7 @@ namespace Indexer.ViewModel
             CurrentLabels.TriggerReset();
             OnPropertyChanged(nameof(CurrentLabel));
             OnPropertyChanged(nameof(CurrentLabels));
+            OnPropertyChanged(nameof(SavedPosition));
             OnPropertyChanged(nameof(SavedPositionText));
         }
 
@@ -377,6 +381,7 @@ namespace Indexer.ViewModel
 
             OnPropertyChanged(nameof(CurrentLabel));
             OnPropertyChanged(nameof(CurrentLabels));
+            OnPropertyChanged(nameof(SavedPosition));
             OnPropertyChanged(nameof(SavedPositionText));
         }
 
@@ -436,6 +441,7 @@ namespace Indexer.ViewModel
 
             IsSessionModified = true;
             OnPropertyChanged(nameof(CurrentLabel));
+            OnPropertyChanged(nameof(SavedPosition));
             OnPropertyChanged(nameof(SavedPositionText));
             OnPropertyChanged(nameof(CurrentHint));
             OnPropertyChanged(nameof(CurrentHintImage));


### PR DESCRIPTION
Refactor of the part that has bothered me before:

> - dependence on `LabelViewModel` is not ideal for a component that could be universal but the truth is that we ain't going to need it

https://github.com/Jackenmen/PG_INF_PG_9KISI2023/pull/39#issuecomment-1575002137

I only really did it because I already had to rework LabelViewModel (PR incoming).