### PR TITLE
Remember last export file name for Export As save dialogs

### DIFF
--- a/src/Indexer/View/Commands.cs
+++ b/src/Indexer/View/Commands.cs
@@ -24,6 +24,10 @@ namespace Indexer.View
             "Save Session As", "SaveSessionAs", typeof(Commands)
         );
 
+        public static RoutedUICommand ExportTo = new RoutedUICommand(
+            "Export To", "ExportTo", typeof(Commands)
+        );
+
         public static RoutedUICommand ExportAsCSV = new RoutedUICommand(
             "Export As CSV", "ExportAsCSV", typeof(Commands)
         );

--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -42,6 +42,10 @@
             Executed="SaveSessionAs_Click"
             CanExecute="CanExecute_IsSessionOpen" />
         <CommandBinding
+            Command="{x:Static commands:Commands.ExportTo}"
+            Executed="ExportTo_Click"
+            CanExecute="CanExecute_HasExportedBefore" />
+        <CommandBinding
             Command="{x:Static commands:Commands.ExportAsCSV}"
             Executed="ExportAsCSV_Click"
             CanExecute="CanExecute_IsSessionOpen" />
@@ -93,6 +97,10 @@
             Key="S"
             Modifiers="Ctrl+Shift"
             Command="{x:Static commands:Commands.SaveSessionAs}" />
+        <KeyBinding
+            Key="E"
+            Modifiers="Ctrl"
+            Command="{x:Static commands:Commands.ExportTo}" />
         <KeyBinding
             Key="C"
             Modifiers="Alt"
@@ -149,15 +157,25 @@
                         InputGestureText="Ctrl+Shift+S"
                         Command="{x:Static commands:Commands.SaveSessionAs}" />
                     <MenuItem
-                        Header="Wyeksportuj do..."
+                        Header="{Binding LastExportFileName}"
+                        HeaderStringFormat="Wyeksportuj do {0}"
+                        InputGestureText="Ctrl+E"
+                        IsEnabled="{Binding IsSessionOpen}"
+                        Visibility="{
+                            Binding HasExportedBefore,
+                            Converter={StaticResource BooleanToVisibilityConverter}
+                        }"
+                        Command="{x:Static commands:Commands.ExportTo}" />
+                    <MenuItem
+                        Header="Wyeksportuj jako..."
                         IsEnabled="{Binding IsSessionOpen}"
                     >
                         <MenuItem
-                            Header="pliku CSV"
+                            Header="plik CSV"
                             InputGestureText="Alt+C"
                             Command="{x:Static commands:Commands.ExportAsCSV}" />
                         <MenuItem
-                            Header="pliku XML"
+                            Header="plik XML"
                             InputGestureText="Alt+X"
                             Command="{x:Static commands:Commands.ExportAsXML}" />
                     </MenuItem>

--- a/src/Indexer/View/MainWindow.xaml.cs
+++ b/src/Indexer/View/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 using System.ComponentModel;
 using System.Diagnostics;
+using System.IO;
 using System.Reflection;
 using System.Runtime.Serialization;
 using System.Windows;
@@ -34,6 +35,11 @@ namespace Indexer.View
         )
         {
             e.CanExecute = Data.IsSessionModified;
+        }
+
+        private void CanExecute_HasExportedBefore(object sender, CanExecuteRoutedEventArgs e)
+        {
+            e.CanExecute = Data.HasExportedBefore;
         }
 
         private void CanExecute_HasImages(object sender, CanExecuteRoutedEventArgs e)
@@ -247,6 +253,11 @@ namespace Indexer.View
             }
         }
 
+        private void ExportTo_Click(object sender, RoutedEventArgs e)
+        {
+            Data.ExportToLastFile();
+        }
+
         private void ExportAsCSV_Click(object sender, RoutedEventArgs e)
         {
             var fileLocation = PromptForExportLocation("csv");
@@ -269,15 +280,25 @@ namespace Indexer.View
             Data.ExportPointsToXML(fileLocation);
         }
 
-        private static string? PromptForExportLocation(string fileExt)
+        private string? PromptForExportLocation(string fileExt)
         {
+            string? path = null;
+            Data.LastExportPaths.TryGetValue(fileExt, out path);
             var saveFileDialog = new SaveFileDialog()
             {
                 Title = $"Eksportuj do pliku {fileExt.ToUpperInvariant()}",
                 DefaultExt = fileExt,
-                Filter = $"Pliki {fileExt.ToUpperInvariant()}|*.{fileExt}",
-                RestoreDirectory = true
+                Filter = $"Pliki {fileExt.ToUpperInvariant()}|*.{fileExt}"
             };
+            if (path is not null)
+            {
+                saveFileDialog.InitialDirectory = Path.GetDirectoryName(path);
+                saveFileDialog.FileName = Path.GetFileName(path);
+            }
+            else
+            {
+                saveFileDialog.RestoreDirectory = true;
+            }
             if (saveFileDialog.ShowDialog() == true)
             {
                 return saveFileDialog.FileName;
@@ -310,8 +331,9 @@ namespace Indexer.View
                 {bullet} Dodaj zdjęcia i/lub foldery: Ctrl+I
                 {bullet} Zapisz sesję: Ctrl+S
                 {bullet} Zapisz sesji jako...: Ctrl+Shift+S
-                {bullet} Wyeksportuj sesję do pliku CSV: Alt+C
-                {bullet} Wyeksportuj sesję do pliku XML: Alt+X
+                {bullet} Wyeksportuj sesję (do ostatniego pliku eksportu): Alt+C
+                {bullet} Wyeksportuj sesję jako plik CSV: Alt+C
+                {bullet} Wyeksportuj sesję jako plik XML: Alt+X
                 {bullet} Zamknij bieżącą sesję: Ctrl+W
                 {bullet} Zamknij aplikację: Alt+F4
                 {bullet} Wyświetl pomoc dot. skrótów klawiaturowych: Ctrl+F1

--- a/src/Indexer/ViewModel/MainViewModel.cs
+++ b/src/Indexer/ViewModel/MainViewModel.cs
@@ -40,6 +40,24 @@ namespace Indexer.ViewModel
                 return Path.GetFileName(_session.FilePath);
             }
         }
+        public bool HasExportedBefore => LastExportType != null;
+        public string? LastExportType { get; private set; }
+        private readonly Dictionary<string, string> _LastExportPaths = new();
+        public ReadOnlyDictionary<string, string> LastExportPaths =>
+            new(_LastExportPaths);
+        public string? LastExportPath =>
+            LastExportType != null ? LastExportPaths[LastExportType] : null;
+        public string? LastExportFileName
+        {
+            get
+            {
+                if (LastExportType == null)
+                {
+                    return null;
+                }
+                return Path.GetFileName(LastExportPaths[LastExportType]);
+            }
+        }
         public string SessionFileTitle => _session?.FilePath ?? "Bez tytułu";
         public bool IsSessionOpen => _session != null;
         public bool IsSessionOnDisk => _session != null && _session.FilePath != null;
@@ -189,6 +207,8 @@ namespace Indexer.ViewModel
                     SetCurrentImageIndex(_session.CurrentImageIndex, desynced: true);
                 }
             }
+            LastExportType = null;
+            _LastExportPaths.Clear();
             OnPropertyChanged(nameof(IsSessionOpen));
             OnPropertyChanged(nameof(IsSessionOnDisk));
             OnPropertyChanged(nameof(Title));
@@ -201,6 +221,10 @@ namespace Indexer.ViewModel
             OnPropertyChanged(nameof(CurrentBitmapImage));
             OnPropertyChanged(nameof(CurrentLabels));
             OnPropertyChanged(nameof(HasImages));
+            OnPropertyChanged(nameof(LastExportType));
+            OnPropertyChanged(nameof(LastExportPath));
+            OnPropertyChanged(nameof(LastExportFileName));
+            OnPropertyChanged(nameof(HasExportedBefore));
         }
 
         public void AddIndexedImages([NotNull] IEnumerable<string> imagePaths)
@@ -448,6 +472,27 @@ namespace Indexer.ViewModel
             OnPropertyChanged(nameof(CurrentHintBitmapImage));
         }
 
+        public void ExportToLastFile()
+        {
+            if (_session is null)
+            {
+                throw new InvalidOperationException("No session is open.");
+            }
+            if (LastExportType is null || LastExportPath is null)
+            {
+                throw new InvalidOperationException("The file to export to is unknown.");
+            }
+            switch (LastExportType)
+            {
+                case "xml":
+                    ExportPointsToXML(LastExportPath);
+                    break;
+                case "csv":
+                    ExportPointsToCSV(LastExportPath);
+                    break;
+            }
+        }
+
         public void ExportPointsToXML([NotNull] string filePath)
         {
             if (_session is null)
@@ -455,6 +500,13 @@ namespace Indexer.ViewModel
                 throw new InvalidOperationException("No session is open.");
             }
             _session.ExportPointsToXML(filePath);
+            var exportType = "xml";
+            _LastExportPaths[exportType] = filePath;
+            LastExportType = exportType;
+            OnPropertyChanged(nameof(LastExportType));
+            OnPropertyChanged(nameof(LastExportPath));
+            OnPropertyChanged(nameof(LastExportFileName));
+            OnPropertyChanged(nameof(HasExportedBefore));
         }
 
         public void ExportPointsToCSV([NotNull] string filePath)
@@ -464,6 +516,13 @@ namespace Indexer.ViewModel
                 throw new InvalidOperationException("No session is open.");
             }
             _session.ExportPointsToCSV(filePath);
+            var exportType = "csv";
+            _LastExportPaths[exportType] = filePath;
+            LastExportType = exportType;
+            OnPropertyChanged(nameof(LastExportType));
+            OnPropertyChanged(nameof(LastExportPath));
+            OnPropertyChanged(nameof(LastExportFileName));
+            OnPropertyChanged(nameof(HasExportedBefore));
         }
     }
 }


### PR DESCRIPTION
Improves user experience in a few ways by remembering the last export file names for each export type *and* remembering the last file we exported to. This allows us to show the previous export location in Export As prompt *and* it allows us to show an additional "Export to filename.ext" if the user exported at least once.