### PR TITLE
Transform Keyboard Shortcut menu into Short Help

### DIFF
--- a/src/Indexer/View/Commands.cs
+++ b/src/Indexer/View/Commands.cs
@@ -44,8 +44,8 @@ namespace Indexer.View
             "Exit", "Exit", typeof(Commands)
         );
 
-        public static RoutedUICommand KeyboardShortcuts = new RoutedUICommand(
-            "Keyboard Shortcuts", "KeyboardShortcuts", typeof(Commands)
+        public static RoutedUICommand ShortHelp = new RoutedUICommand(
+            "Short Help", "ShortHelp", typeof(Commands)
         );
 
         public static RoutedUICommand AboutIndexer = new RoutedUICommand(

--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -65,8 +65,8 @@
             Command="{x:Static commands:Commands.Exit}"
             Executed="Exit_Click" />
         <CommandBinding
-            Command="{x:Static commands:Commands.KeyboardShortcuts}"
-            Executed="ShortcutsHelp_Click" />
+            Command="{x:Static commands:Commands.ShortHelp}"
+            Executed="ShortHelp_Click" />
         <CommandBinding
             Command="{x:Static commands:Commands.AboutIndexer}"
             Executed="About_Click" />
@@ -124,7 +124,7 @@
         <KeyBinding
             Key="F1"
             Modifiers="Ctrl"
-            Command="{x:Static commands:Commands.KeyboardShortcuts}" />
+            Command="{x:Static commands:Commands.ShortHelp}" />
         <KeyBinding
             Key="Tab"
             Modifiers="Ctrl"
@@ -201,9 +201,9 @@
                 </MenuItem>
                 <MenuItem Header="Pomoc" Focusable="false">
                     <MenuItem
-                        Header="Skróty klawiaturowe"
+                        Header="Skrócona instrukcja obsługi"
                         InputGestureText="Ctrl+F1"
-                        Command="{x:Static commands:Commands.KeyboardShortcuts}" />
+                        Command="{x:Static commands:Commands.ShortHelp}" />
                     <MenuItem
                         Header="O programie"
                         Command="{x:Static commands:Commands.AboutIndexer}" />

--- a/src/Indexer/View/MainWindow.xaml.cs
+++ b/src/Indexer/View/MainWindow.xaml.cs
@@ -326,7 +326,7 @@ namespace Indexer.View
             return null;
         }
 
-        private void ShortcutsHelp_Click(object sender, RoutedEventArgs e)
+        private void ShortHelp_Click(object sender, RoutedEventArgs e)
         {
             var bullet = "\u2022";
             var arrows = "\u2191/\u2193/\u2192/\u2190";
@@ -335,6 +335,8 @@ namespace Indexer.View
                 caption: Data.ProgramName,
                 messageBoxText: $"""
                 Etykietowanie zdjęć:
+                {bullet} Przesuń etykietę do lokalizacji kursora myszy: Lewy przycisk myszy
+                {bullet} Usuń współrzędne obecnej etykiety: Prawy przycisk myszy/Delete
                 {bullet} Przesuń etykietę o 1 piksel: {arrows}
                 {bullet} Przesuń etykietę o 4 piksele: Ctrl+{arrows}
                 {bullet} Przesuń etykietę o 25 pikseli: Shift+{arrows}


### PR DESCRIPTION
I actually just wanted to add the new `Delete` key binding and mention the mouse button bindings but the latter didn't really fit into "Keyboard shortcuts" so I renamed this menu entry.