### PR TITLE
Changed magnifier width

### DIFF
--- a/src/Indexer/View/MainWindow.xaml
+++ b/src/Indexer/View/MainWindow.xaml
@@ -501,6 +501,7 @@
                                 SavedPosition="{Binding SavedPosition}"
                                 ImageCursor="{Binding ImageCursorPosition}"
                                 Height="250"
+                                Width="250"
                                 Grid.Row="2" />
                             <Slider
                                 Minimum="1"


### PR DESCRIPTION
Right now the magnifier stretches in width to fit available space. I don't think it was intentional.
![Screenshot (955)](https://github.com/pginf-pg-9kisi2023/indexer-app/assets/111705987/bcbd5905-7167-4871-bcf7-94c593106640)
Changed the magnifier to have fixed width the same as it has a fixed height.
![Screenshot (957)](https://github.com/pginf-pg-9kisi2023/indexer-app/assets/111705987/8ea2e763-589b-42c3-853f-5f7f284478ac)
It could be an interesting idea to make the magnifier (width and height) stretch to fit available space in the right panel.