### PR TITLE
Fix inability to select points after image analysis

### DIFF
--- a/src/Indexer/ViewModel/MainViewModel.cs
+++ b/src/Indexer/ViewModel/MainViewModel.cs
@@ -570,6 +570,10 @@ namespace Indexer.ViewModel
                 from indexedImage in _session.IndexedImages
                 select new IndexedImageViewModel(_session, indexedImage)
             );
+            if (IndexedImages.Count != 0)
+            {
+                SetCurrentImageIndex(_session.CurrentImageIndex, desynced: true);
+            }
             IsSessionModified = true;
             OnPropertyChanged(nameof(IndexedImages));
             OnPropertyChanged(nameof(CurrentBitmapImage));


### PR DESCRIPTION
This updates the `MainViewModel.AnalyzeImages()` to follow the same logic for updating indexed images that we have in `SetSession()`. Without it, some of the references remained outdated after the collection update.