### PR TITLE
Fix max X/Y values when moving with arrow keys

### DIFF
--- a/src/Indexer/ViewModel/MainViewModel.cs
+++ b/src/Indexer/ViewModel/MainViewModel.cs
@@ -379,10 +379,10 @@ namespace Indexer.ViewModel
             }
 
             currentLabel.X = Math.Min(
-                Math.Max(0, currentLabel.X + x), CurrentIndexedImage.Image.Width
+                Math.Max(0, currentLabel.X + x), CurrentIndexedImage.Image.Width - 1
             );
             currentLabel.Y = Math.Min(
-                Math.Max(0, currentLabel.Y + y), CurrentIndexedImage.Image.Height
+                Math.Max(0, currentLabel.Y + y), CurrentIndexedImage.Image.Height - 1
             );
             CurrentLabels.TriggerReset();
             IsSessionModified = true;


### PR DESCRIPTION
I noticed that we actually allow out-of-bounds values when using arrow keys, e.g. 1000x1000 image has positions from (0, 0) to (999, 999) but we allowed (1000, 1000)