### PR TITLE
Fix missing binding for child properties in ImageWithLabels

### DIFF
--- a/src/Indexer/View/ImageWithLabels.cs
+++ b/src/Indexer/View/ImageWithLabels.cs
@@ -95,6 +95,13 @@ namespace Indexer.View
             Canvas.SetBinding(
                 HeightProperty, new Binding("ActualHeight") { Source = Image }
             );
+            Image.SetBinding(
+                StretchProperty, new Binding("Stretch") { Source = this }
+            );
+            Image.SetBinding(
+                StretchDirectionProperty,
+                new Binding("StretchDirection") { Source = this }
+            );
             Children.Add(Image);
             Children.Add(Canvas);
             Image.SizeChanged += OnImageSizeChange;


### PR DESCRIPTION
Turns out that this wasn't bound in our custom component which resulted in smaller images incorrectly getting upscaled beyond their actual size.