### PR TITLE
Decrease reallocations by using WritableBitmap in Magnifier

### DIFF
--- a/src/Indexer/View/Magnifier.cs
+++ b/src/Indexer/View/Magnifier.cs
@@ -89,7 +89,7 @@ namespace Indexer.View
         private System.Drawing.Image? BaseImage;
         private System.Drawing.Graphics? Graphics;
         private System.Drawing.Bitmap? Bitmap;
-        protected WriteableBitmap? BitmapSource;
+        private WriteableBitmap? BitmapSource;
         private readonly Image MagnifierImage =
             new()
             {
@@ -396,10 +396,10 @@ namespace Indexer.View
             var rectHeight = Math.Min(PixelHeight, BaseImage.Height * ZoomFactor - rectY);
 
             var sourceRect = new Int32Rect(rectX, rectY, rectWidth, rectHeight);
-            var imageBitmap = GenerateImageBitmap(sourceRect);
+            GenerateImageBitmap(sourceRect);
             var transform = new TranslateTransform(offsetX, offsetY);
 
-            MagnifierImage.Source = imageBitmap;
+            MagnifierImage.Source = BitmapSource;
             MagnifierImage.RenderTransform = transform;
             MagnifierImage.Clip = new RectangleGeometry(new Rect(0, 0, rectWidth, rectHeight));
         }
@@ -412,15 +412,15 @@ namespace Indexer.View
         )]
         private static extern void CopyMemory(IntPtr dest, IntPtr source, int Length);
 
-        private BitmapSource? GenerateImageBitmap(Int32Rect sourceRect)
+        private void GenerateImageBitmap(Int32Rect sourceRect)
         {
             if (Bitmap is null)
             {
-                return null;
+                return;
             }
             if (!sourceRect.HasArea)
             {
-                return null;
+                return;
             }
 
             // Top-left corner of the source portion of the image.
@@ -475,7 +475,6 @@ namespace Indexer.View
             {
                 Bitmap.UnlockBits(data);
             }
-            return BitmapSource;
         }
     }
 }


### PR DESCRIPTION
Improvement for the feature implemented in #81 - as explained in one of its commits, moving the mouse a lot has sometimes stopped the magnifier from moving (mainly under a debugger) which was caused by a large number of new allocations whenever the image changed (due to having to recreate `BitmapImage` from `MemoryStream`). This was the cause of a large number of GC calls which can be pretty demanding.

This PR fixes all this by using a reusable `BitmapSource` type - `WriteableBitmap`. Whenever we generate an updated bitmap, we now copy its bits directly into the writeable bitmap's back buffer. Doing this efficiently seems to require using unmanaged code which is a bit of a bummer but the performance benefit seems worth it. This is actually a reason why this wasn't done in #81 - I wanted to first have a working safe implementation merged.